### PR TITLE
Fix set-wallpaper binary location

### DIFF
--- a/debian/switchboard-plug-pantheon-shell.install
+++ b/debian/switchboard-plug-pantheon-shell.install
@@ -1,3 +1,3 @@
-usr/bin
+usr/libexec
 usr/lib
 usr/share

--- a/set-wallpaper-contract/CMakeLists.txt
+++ b/set-wallpaper-contract/CMakeLists.txt
@@ -1,19 +1,21 @@
-
-set (TARGET "set-wallpaper")
+set (EXEC_NAME "set-wallpaper")
 set (SOURCES "set-wallpaper.vala")
+set (SWEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/switchboard-plug-pantheon-shell")
 set (DEPENDENCIES granite posix)
+
+configure_file (set-wallpaper.contract.in ${CMAKE_CURRENT_BINARY_DIR}/set-wallpaper.contract)
 
 find_package (PkgConfig)
 pkg_check_modules (DEPS REQUIRED ${DEPENDENCIES})
 
-vala_precompile (WALLPAPER_CONTRACT_VALA_C ${TARGET} ${SOURCES} PACKAGES ${DEPENDENCIES})
-add_executable (${TARGET} ${WALLPAPER_CONTRACT_VALA_C})
+vala_precompile (WALLPAPER_CONTRACT_VALA_C ${EXEC_NAME} ${SOURCES} PACKAGES ${DEPENDENCIES})
+add_executable (${EXEC_NAME} ${WALLPAPER_CONTRACT_VALA_C})
 
 link_directories (${DEPS_LIBRARY_DIRS})
-target_link_libraries (${TARGET} m ${DEPS_LIBRARIES})
-set_target_properties (${TARGET} PROPERTIES
+target_link_libraries (${EXEC_NAME} m ${DEPS_LIBRARIES})
+set_target_properties (${EXEC_NAME} PROPERTIES
 	COMPILE_OPTIONS "${DEPS_CFLAGS} -DGETTEXT_PACKAGE=${GETTEXT_PACKAGE}")
 
-install (TARGETS ${TARGET} DESTINATION bin)
-install (FILES ${CMAKE_CURRENT_SOURCE_DIR}/set-wallpaper.contract DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/contractor)
+install (TARGETS ${EXEC_NAME} DESTINATION ${SWEXECDIR})
+install (FILES ${CMAKE_CURRENT_BINARY_DIR}/set-wallpaper.contract DESTINATION ${CMAKE_INSTALL_FULL_DATAROOTDIR}/contractor)
 

--- a/set-wallpaper-contract/set-wallpaper.contract.in
+++ b/set-wallpaper-contract/set-wallpaper.contract.in
@@ -3,5 +3,5 @@ Name=Set as _Desktop Background
 Icon=preferences-desktop-wallpaper
 Description=Set selected image to be the new desktop background
 MimeType=image
-Exec=set-wallpaper %F
+Exec=${SWEXECDIR}/${EXEC_NAME} %F
 X-GNOME-Gettext-Domain=pantheon-desktop-plug


### PR DESCRIPTION
Fix #6. Install set-wallpaper binary to /usr/libexec/switchboard-plug-pantheon-shell.