### PR TITLE
Create local background directory if necessary

### DIFF
--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -474,6 +474,17 @@ public class Wallpaper : Gtk.Grid {
         File? dest = null;
 
         try {
+            File folder = File.new_for_path (get_local_bg_location ());
+            folder.make_directory_with_parents ();
+        } catch (Error e) {
+            if (e is GLib.IOError.EXISTS) {
+                debug ("Local background directory already exists");
+            } else {
+                warning (e.message);
+            }
+        }
+
+        try {
             dest = File.new_for_path (get_local_bg_location () + source.get_basename ());
             source.copy (dest, FileCopyFlags.OVERWRITE | FileCopyFlags.ALL_METADATA);
         } catch (Error e) {


### PR DESCRIPTION
Fix #40 .

On a fresh installation of elementary the `/home/<user>/.local/share/backgrounds/` directory may not exist. Ensure we create it, otherwise we end up not being able to set the background to a custom one the user chooses because the subsequent copy to that directory fails.