### PR TITLE
set-wallpaper-contract/CMakeLists.txt: fix posix dependency

### DIFF
--- a/set-wallpaper-contract/CMakeLists.txt
+++ b/set-wallpaper-contract/CMakeLists.txt
@@ -1,14 +1,14 @@
 set (EXEC_NAME "set-wallpaper")
 set (SOURCES "set-wallpaper.vala")
 set (SWEXECDIR "${CMAKE_INSTALL_FULL_LIBEXECDIR}/switchboard-plug-pantheon-shell")
-set (DEPENDENCIES granite posix)
+set (DEPENDENCIES granite)
 
 configure_file (set-wallpaper.contract.in ${CMAKE_CURRENT_BINARY_DIR}/set-wallpaper.contract)
 
 find_package (PkgConfig)
 pkg_check_modules (DEPS REQUIRED ${DEPENDENCIES})
 
-vala_precompile (WALLPAPER_CONTRACT_VALA_C ${EXEC_NAME} ${SOURCES} PACKAGES ${DEPENDENCIES})
+vala_precompile (WALLPAPER_CONTRACT_VALA_C ${EXEC_NAME} ${SOURCES} PACKAGES ${DEPENDENCIES} posix)
 add_executable (${EXEC_NAME} ${WALLPAPER_CONTRACT_VALA_C})
 
 link_directories (${DEPS_LIBRARY_DIRS})


### PR DESCRIPTION
pkg-config doesn't know about the non-existent "posix" module, so it exits and complains it doesn't exist.
The posix dependency needs to be present only in the CMake function "vala_precompile".