### PR TITLE
Fix gee_abstract_map_clear warnings; improve performance

### DIFF
--- a/src/desktop-plug.vala
+++ b/src/desktop-plug.vala
@@ -39,6 +39,8 @@ public class GalaPlug : Switchboard.Plug {
 
     public override Gtk.Widget get_widget () {
         if (main_grid == null) {
+            Cache.init ();
+            
             main_grid = new Gtk.Grid ();
 
             var wallpaper = new Wallpaper (this);


### PR DESCRIPTION
Fixes `gee_abstract_map_clear: assertion 'self != NULL' failed` warnings and improves performance by removing redundant usage of `compute_key` multiple times for the same uri. Makes constructing paths and filenames use native `GLib` methods.