### PR TITLE
Fix get int32 warnings

### DIFF
--- a/src/GalaSettings.vala
+++ b/src/GalaSettings.vala
@@ -26,10 +26,10 @@ public class BehaviorSettings : Granite.Services.Settings {
     public string panel_main_menu_action { get; set; }
     public string toggle_recording_action { get; set; }
 
-    public int hotcorner_topleft { get; set; }
-    public int hotcorner_topright { get; set; }
-    public int hotcorner_bottomleft { get; set; }
-    public int hotcorner_bottomright { get; set; }
+    public string hotcorner_topleft { get; set; }
+    public string hotcorner_topright { get; set; }
+    public string hotcorner_bottomleft { get; set; }
+    public string hotcorner_bottomright { get; set; }
 
     public string hotcorner_custom_command { get; set; }
 

--- a/src/GalaSettings.vala
+++ b/src/GalaSettings.vala
@@ -26,11 +26,6 @@ public class BehaviorSettings : Granite.Services.Settings {
     public string panel_main_menu_action { get; set; }
     public string toggle_recording_action { get; set; }
 
-    public string hotcorner_topleft { get; set; }
-    public string hotcorner_topright { get; set; }
-    public string hotcorner_bottomleft { get; set; }
-    public string hotcorner_bottomright { get; set; }
-
     public string hotcorner_custom_command { get; set; }
 
     static BehaviorSettings? instance = null;


### PR DESCRIPTION
For now we don't need these settings, as the code doesn't use any of these properties and sets them manually through the `schema` in this settings object. With these Granite also throws warnings like:
`g_variant_get_int32: assertion 'g_variant_is_of_type (value, G_VARIANT_TYPE_INT32)' failed`