### PR TITLE
Make stack switcher homogeneous

### DIFF
--- a/src/desktop-plug.vala
+++ b/src/desktop-plug.vala
@@ -55,6 +55,7 @@ public class GalaPlug : Switchboard.Plug {
             var stack_switcher = new Gtk.StackSwitcher ();
             stack_switcher.stack = stack;
             stack_switcher.halign = Gtk.Align.CENTER;
+            stack_switcher.homogeneous = true;
             stack_switcher.margin = 24;
 
             main_grid.attach (stack_switcher, 0, 0, 1, 1);


### PR DESCRIPTION
Stack switchers no longer have homogeneous button widths by default in 3.22