### PR TITLE
Reset picture options if a solid color has been set

### DIFF
--- a/set-wallpaper-contract/set-wallpaper.vala
+++ b/set-wallpaper-contract/set-wallpaper.vala
@@ -72,6 +72,9 @@ namespace SetWallpaperContractor {
     private void set_settings_key (string uri) {
         var settings = new Settings ("org.gnome.desktop.background");
         settings.set_string ("picture-uri", uri);
+        if (settings.get_string ("picture-options") == "none") {
+            settings.reset ("picture-options");
+        }
         settings.apply ();
         Settings.sync ();
     }


### PR DESCRIPTION
Fixes #4.

When setting a wallpaper with the contract, if the picture options have been set to `none` (i.e. after a solid color has been applied), nothing happened before. This resets the key to default to allow the wallpaper to show.