### PR TITLE
Stop the currently selected wallpaper being unchecked when reselecting

### DIFF
--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -274,7 +274,7 @@ public class Wallpaper : Gtk.Grid {
 
         children.checked = true;
 
-        if (active_wallpaper != null) {
+        if (active_wallpaper != null && active_wallpaper != children) {
             active_wallpaper.checked = false;
         }
 


### PR DESCRIPTION
Fixes #76 