### PR TITLE
Display artist data in tooltip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="cmake libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libplank-dev libswitchboard-2.0-dev valac"
+ - DEPENDENCY_PACKAGES="cmake libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libplank-dev libswitchboard-2.0-dev libgexiv2-dev valac"
 
 install:
  - docker pull elementary/docker:loki

--- a/debian/control
+++ b/debian/control
@@ -9,6 +9,7 @@ Build-Depends: cmake (>= 2.8),
                libgtk-3-dev (>= 3.14),
                libplank-dev,
                libswitchboard-2.0-dev,
+               libgexiv2-dev,
                valac (>= 0.26)
 Standards-Version: 3.9.6
 Homepage: https://launchpad.net/switchboard-plug-pantheon-shell

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Add all your dependencies to the list below
-pkg_check_modules (DEPS REQUIRED glib-2.0 switchboard-2.0 granite gtk+-3.0>=3.14 gnome-desktop-3.0 plank>=0.7.1.1137)
+pkg_check_modules (DEPS REQUIRED glib-2.0 switchboard-2.0 granite gtk+-3.0>=3.14 gexiv2 gnome-desktop-3.0 plank>=0.7.1.1137)
 
 pkg_check_modules(PLANK011 QUIET plank>=0.10.9)
 if (PLANK011_FOUND)
@@ -30,6 +30,7 @@ PACKAGES
     gnome-desktop-3.0
     switchboard-2.0
     granite
+    gexiv2
     posix
     plank
 OPTIONS

--- a/src/Widgets/WallpaperContainer.vala
+++ b/src/Widgets/WallpaperContainer.vala
@@ -168,7 +168,30 @@ public class WallpaperContainer : Gtk.FlowBoxChild {
         });
     }
 
+    private void load_artist_tooltip () {
+        if (uri != null) {
+            string path = "";
+            GExiv2.Metadata metadata;
+            try {
+                path = Filename.from_uri (uri);
+                metadata = new GExiv2.Metadata ();
+                metadata.open_path (path);
+            } catch (Error e) {
+                warning ("Error parsing exif metadata of \"%s\": %s", path, e.message);
+                return;
+            }
+
+            if (metadata.has_exif ()) {
+                var artist_name = metadata.get_tag_string ("Exif.Image.Artist");
+                if (artist_name != null) {
+                    set_tooltip_text (_("Artist: %s").printf (artist_name));
+                }
+            }
+        }
+    }
+
     private void thumb_ready () {
         image.gicon = thumb;
+        load_artist_tooltip ();
     }
 }


### PR DESCRIPTION
Fixes #81 

![screenshot from 2017-10-01 16 43 18](https://user-images.githubusercontent.com/3372394/31056321-bd8dd424-a6c7-11e7-92a6-7aad999416f1.png)

Currently the tooltip only displays for the wallpapers that have an artist tag set. Not sure if that's the correct behavior and whether or not the tooltip should always show. If so, what information should appear?