### PR TITLE
Revert size to 162x100

### DIFF
--- a/src/Widgets/WallpaperContainer.vala
+++ b/src/Widgets/WallpaperContainer.vala
@@ -19,8 +19,8 @@
  */
 
 public class WallpaperContainer : Gtk.FlowBoxChild {
-    private const int THUMB_WIDTH = 128;
-    private const int THUMB_HEIGHT = 72;
+    private const int THUMB_WIDTH = 162;
+    private const int THUMB_HEIGHT = 100;
 
     private Gtk.Revealer check_revealer;
     private Gtk.Image image;


### PR DESCRIPTION
Fixes #78 

Thumbnails show now be back to the previous size before switching to tumbler for thumbnails.