### PR TITLE
Refactor Wallpaper.vala v2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ vala_precompile (VALA_C ${PLUGNAME}
     ThumbnailGenerator.vala
     desktop-plug.vala
     GalaSettings.vala
+    IOHelper.vala
     Views/Dock.vala
     Views/HotCorners.vala
     Views/Wallpaper.vala

--- a/src/IOHelper.vala
+++ b/src/IOHelper.vala
@@ -1,0 +1,42 @@
+/*-
+ * Copyright (c) 2017-2018 elementary LLC.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+public class IOHelper : GLib.Object {
+    private const string[] ACCEPTED_TYPES = {
+        "image/jpeg",
+        "image/png",
+        "image/tiff",
+        "image/svg+xml",
+        "image/gif"
+    };
+
+    // Check if the filename has a picture file extension.
+    public static bool is_valid_file_type (GLib.FileInfo file_info) {
+        // Check for correct file type, don't try to load directories and such
+        if (file_info.get_file_type () != GLib.FileType.REGULAR) {
+            return false;
+        }
+
+        foreach (var type in ACCEPTED_TYPES) {
+            if (GLib.ContentType.equals (file_info.get_content_type (), type)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
A follow up to https://github.com/elementary/switchboard-plug-pantheon-shell/pull/50, but without changing anything in the UI or behaviour. 

A preparation for https://github.com/elementary/switchboard-plug-pantheon-shell/issues/32.

* IOHelper in a separate file
* Let warning () format the warning string
* Make some methods static that didn't use anything from the instance
* Constant name to `UPPER_CASE`
* Code simplifications
* Remove unneded Gtk main iteration call
* Fix code style