### PR TITLE
Fix HiDPI thumb sizes

### DIFF
--- a/src/Widgets/WallpaperContainer.vala
+++ b/src/Widgets/WallpaperContainer.vala
@@ -188,7 +188,7 @@ public class WallpaperContainer : Gtk.FlowBoxChild {
         }
 
         try {
-            yield image.set_from_file_async (File.new_for_path (thumb_path), THUMB_WIDTH * scale, THUMB_HEIGHT * scale, false);
+            yield image.set_from_file_async (File.new_for_path (thumb_path), THUMB_WIDTH, THUMB_HEIGHT, false);
         } catch (Error e) {
             warning (e.message);
         }


### PR DESCRIPTION
Fixes #90.

This fixes an incorrect usage of the width and height parameters of `set_from_file_async` to `Granite.AsyncImage`, this API already takes care of the scale factor.