### PR TITLE
Use file paths instead of URIs for wallpaper folders

### DIFF
--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -322,11 +322,8 @@ public class Wallpaper : Gtk.Grid {
 
         clean_wallpapers ();
 
-        var system_uri = "file://" + SYSTEM_BACKGROUNDS_PATH;
-        var user_uri = GLib.File.new_for_path (get_local_bg_location ()).get_uri ();
-
-        load_wallpapers.begin (system_uri, cancellable);
-        load_wallpapers.begin (user_uri, cancellable);
+        load_wallpapers.begin (SYSTEM_BACKGROUNDS_PATH, cancellable);
+        load_wallpapers.begin (get_local_bg_location (), cancellable);
     }
 
     private async void load_wallpapers (string basefolder, Cancellable cancellable, bool toplevel_folder = true) {
@@ -334,7 +331,7 @@ public class Wallpaper : Gtk.Grid {
             return;
         }
 
-        var directory = File.new_for_uri (basefolder);
+        var directory = File.new_for_path (basefolder);
 
         try {
             // Enumerator object that will let us read through the wallpapers asynchronously


### PR DESCRIPTION
Fixes #157 

The issue was actually here (with using `get_path` instead of `get_uri`):
https://github.com/elementary/switchboard-plug-pantheon-shell/blob/master/src/Views/Wallpaper.vala#L359

But... since everything is already a path and we're doing stuff to convert it to a URI, why not just use a path throughout.