### PR TITLE
Lazy load wallpapers to improve opening times

### DIFF
--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -80,6 +80,7 @@ public class Wallpaper : Gtk.Grid {
         var separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
 
         wallpaper_view = new Gtk.FlowBox ();
+        wallpaper_view.valign = Gtk.Align.START;
         wallpaper_view.activate_on_single_click = true;
         wallpaper_view.get_style_context ().add_class (Gtk.STYLE_CLASS_VIEW);
         wallpaper_view.homogeneous = true;

--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -377,13 +377,7 @@ public class Wallpaper : Gtk.Grid {
                     solid_color.checked = true;
                     active_wallpaper = solid_color;
                 }
-
-                if (active_wallpaper != null) {
-                    Gtk.Allocation alloc;
-                    active_wallpaper.get_allocation (out alloc);
-                    wallpaper_scrolled_window.get_vadjustment ().value = alloc.y;
-                }
-            }
+              }
               return false;
             });
 

--- a/src/Widgets/WallpaperContainer.vala
+++ b/src/Widgets/WallpaperContainer.vala
@@ -79,9 +79,6 @@ public class WallpaperContainer : Gtk.FlowBoxChild {
         height_request = THUMB_HEIGHT + 18;
         width_request = THUMB_WIDTH + 18;
 
-        var provider = new Gtk.CssProvider ();
-        provider.load_from_resource ("/io/elementary/switchboard/plug/pantheon-shell/plug.css");
-        Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
 
         image = new Granite.AsyncImage ();
         image.halign = Gtk.Align.CENTER;

--- a/src/Widgets/WallpaperContainer.vala
+++ b/src/Widgets/WallpaperContainer.vala
@@ -210,6 +210,9 @@ public class WallpaperContainer : Gtk.FlowBoxChild {
             warning (e.message);
         }
 
-        load_artist_tooltip ();
+        Idle.add(() => {
+          load_artist_tooltip ();
+          return false;
+        }, Priority.LOW);
     }
 }

--- a/src/desktop-plug.vala
+++ b/src/desktop-plug.vala
@@ -43,6 +43,10 @@ public class GalaPlug : Switchboard.Plug {
         if (main_grid == null) {
             main_grid = new Gtk.Grid ();
 
+            var provider = new Gtk.CssProvider ();
+            provider.load_from_resource ("/io/elementary/switchboard/plug/pantheon-shell/plug.css");
+            Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+
             wallpaper_view = new Wallpaper (this);
 
             var hotcorners = new HotCorners ();


### PR DESCRIPTION
Opening times:
before: 1-2s
now: instant

To do this, i removed the while loop and replaced it with an Idle callback inside the main loop.

I removed the finished property because now everything is async and it's difficult to know when everything finishes loading. Anyway, everything still works fine.

Everything being async, jumping to the current wallpaper is bad, because new wallpapers can load after the jump. So i removed it.

Conclusions:
There are some drawbacks, but now it feels smoother and snappier. Now that everything is more responsive, i think the user experience is improved