### PR TITLE
 build: fix install path for switchboard plug

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -2,6 +2,6 @@ i18n.merge_file(
     input: 'io.elementary.switchboard.pantheon-shell.appdata.xml.in',
     output: 'io.elementary.switchboard.pantheon-shell.appdata.xml',
     po_dir: join_paths(meson.source_root (), 'po', 'extra'),
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: join_paths(datadir, 'metainfo'),
     install: true
 )

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,11 @@ gettext_name = meson.project_name() + '-plug'
 gnome = import('gnome')
 i18n = import('i18n')
 
+prefix = get_option('prefix')
+datadir = join_paths(prefix, get_option('datadir'))
+libdir = join_paths(prefix, get_option('libdir'))
+libexecdir = join_paths(prefix, get_option('libexecdir'))
+
 add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format(gettext_name),
     '-DGNOME_DESKTOP_USE_UNSTABLE_API',

--- a/set-wallpaper-contract/meson.build
+++ b/set-wallpaper-contract/meson.build
@@ -1,5 +1,5 @@
 contract_exec_name = 'io.elementary.contract.set-wallpaper'
-contract_path = get_option('libexecdir')
+contract_path = libexecdir
 
 contract_configuration = configuration_data()
 contract_configuration.set('EXEC_NAME', contract_exec_name)
@@ -10,7 +10,7 @@ wallpaper_contract = configure_file(
     input: 'set-wallpaper.contract.in',
     output: '@BASENAME@',
     configuration: contract_configuration,
-    install_dir: join_paths(get_option('prefix'), get_option('datadir'), 'contractor')
+    install_dir: join_paths(datadir, 'contractor')
 )
 
 executable(

--- a/src/meson.build
+++ b/src/meson.build
@@ -12,6 +12,7 @@ plug_files = files(
 )
 
 switchboard_dep = dependency('switchboard-2.0')
+switchboard_plugsdir = switchboard_dep.get_pkgconfig_variable('plugsdir', define_variable: ['libdir', libdir])
 
 plank_datadir = plank_dep.get_pkgconfig_variable('pkgdatadir')
 
@@ -42,5 +43,5 @@ shared_module(
         switchboard_dep
     ],
     install: true,
-    install_dir : join_paths(switchboard_dep.get_pkgconfig_variable('plugsdir'), 'personal')
+    install_dir : join_paths(switchboard_plugsdir, 'personal')
 )


### PR DESCRIPTION
On NixOS all packages are installed into their own immutable prefix.
Because of this switchboard_dep.get_pkgconfig_variable will return a
path from within switchboard's prefix and we cannot write to it.
By using define_variable we can replace the libdir to be from the
paths from meson. This should have no affect on elementaryOS.