### PR TITLE
run installation in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,9 +17,12 @@ jobs:
         apt update
         apt install -y libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libplank-dev libswitchboard-2.0-dev libgexiv2-dev meson valac
     - name: Build
+      env:
+        DESTDIR: out
       run: |
         meson build
         ninja -C build
+        ninja -C build install
 
   lint:
 


### PR DESCRIPTION
This change also runs `ninja install` after `ninja`, and sets the `DESTDIR` variable so no unwanted side effects happen and things get installed into an isolated directory (`/build/out`).