### PR TITLE
Get system background directories from XDG_DATA_DIRS

### DIFF
--- a/set-wallpaper-contract/set-wallpaper.vala
+++ b/set-wallpaper-contract/set-wallpaper.vala
@@ -38,8 +38,6 @@ namespace SetWallpaperContractor {
         </transition>
     """;
 
-    const string SYSTEM_BACKGROUNDS_PATH = "/usr/share/backgrounds";
-
     private int delay_value = 60;
 
     [DBus (name = "org.freedesktop.DisplayManager.AccountsService")]
@@ -110,12 +108,12 @@ namespace SetWallpaperContractor {
         duration_label.set_markup (_("Show each photo for") + " <b>" + text + "</b>");
     }
 
-    private string get_local_bg_location () {
+    private string get_local_bg_directory () {
         return Path.build_filename (Environment.get_user_data_dir (), "backgrounds") + "/";
     }
 
     private File ensure_local_bg_exists () {
-        var folder = File.new_for_path (get_local_bg_location ());
+        var folder = File.new_for_path (get_local_bg_directory ());
         if (!folder.query_exists ()) {
             try {
                 folder.make_directory_with_parents ();
@@ -131,7 +129,7 @@ namespace SetWallpaperContractor {
         File? dest = null;
 
         try {
-            dest = File.new_for_path (get_local_bg_location () + source.get_basename ());
+            dest = File.new_for_path (get_local_bg_directory () + source.get_basename ());
             source.copy (dest, FileCopyFlags.OVERWRITE | FileCopyFlags.ALL_METADATA);
         } catch (Error e) {
             warning ("%s\n", e.message);
@@ -190,7 +188,7 @@ namespace SetWallpaperContractor {
 
                 string path = file.get_path ();
                 File append_file = file;
-                if (!path.has_prefix (SYSTEM_BACKGROUNDS_PATH) && !path.has_prefix (get_local_bg_location ())) {
+                if (!path.has_prefix (get_local_bg_directory ())) {
                     var local_file = copy_for_library (file);
                     if (local_file != null) {
                         append_file = local_file;

--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -39,8 +39,6 @@ public class Wallpaper : Gtk.Grid {
         FileAttribute.THUMBNAIL_IS_VALID
     };
 
-    const string SYSTEM_BACKGROUNDS_PATH = "/usr/share/backgrounds";
-
     public Switchboard.Plug plug { get; construct set; }
     private GLib.Settings settings;
 
@@ -210,7 +208,7 @@ public class Wallpaper : Gtk.Grid {
         string uri = file.get_uri ();
         string path = file.get_path ();
 
-        if (!path.has_prefix (SYSTEM_BACKGROUNDS_PATH) && !path.has_prefix (get_local_bg_location ())) {
+        if (!path.has_prefix (get_local_bg_directory ())) {
             var local_file = copy_for_library (file);
             if (local_file != null) {
                 uri = local_file.get_uri ();
@@ -313,8 +311,9 @@ public class Wallpaper : Gtk.Grid {
 
         clean_wallpapers ();
 
-        load_wallpapers.begin (SYSTEM_BACKGROUNDS_PATH, cancellable);
-        load_wallpapers.begin (get_local_bg_location (), cancellable);
+        foreach (unowned string directory in get_bg_directories ()) {
+            load_wallpapers.begin (directory, cancellable);
+        }
     }
 
     private async void load_wallpapers (string basefolder, Cancellable cancellable, bool toplevel_folder = true) {
@@ -400,16 +399,37 @@ public class Wallpaper : Gtk.Grid {
         solid_color = null;
     }
 
-    private static string get_local_bg_location () {
+    private static string get_local_bg_directory () {
         return Path.build_filename (Environment.get_user_data_dir (), "backgrounds") + "/";
+    }
+
+    private string[] get_bg_directories () {
+        string[] background_directories = {};
+
+        // Add user background directory first
+        background_directories += get_local_bg_directory ();
+
+        foreach (unowned string data_dir in Environment.get_system_data_dirs ()) {
+            var system_background_dir = Path.build_filename (data_dir, "backgrounds") + "/";
+            if (FileUtils.test (system_background_dir, FileTest.EXISTS)) {
+                debug ("Found system background directory: %s", system_background_dir);
+                background_directories += system_background_dir;
+            }
+        }
+
+        if (background_directories.length == 0) {
+            warning ("No background directories found");
+        }
+
+        return background_directories;
     }
 
     private static File? copy_for_library (File source) {
         File? dest = null;
 
-        string local_bg_location = get_local_bg_location ();
+        string local_bg_directory = get_local_bg_directory ();
         try {
-            File folder = File.new_for_path (local_bg_location);
+            File folder = File.new_for_path (local_bg_directory);
             folder.make_directory_with_parents ();
         } catch (Error e) {
             if (e is GLib.IOError.EXISTS) {
@@ -420,7 +440,7 @@ public class Wallpaper : Gtk.Grid {
         }
 
         try {
-            string path = Path.build_filename (local_bg_location, source.get_basename ());
+            string path = Path.build_filename (local_bg_directory, source.get_basename ());
             dest = File.new_for_path (path);
             source.copy (dest, FileCopyFlags.OVERWRITE | FileCopyFlags.ALL_METADATA);
         } catch (Error e) {


### PR DESCRIPTION
Previously the system backgrounds directory was
hardcoded to /usr/share/backgrounds. We now build
paths from entries in system_data_dirs which on elementary OS
should still be /usr/share/backgrounds. This was problematic
for us in NixOS because we break FHS, meaning /usr/share doesn't
exist. However we still set XDG_DATA_DIRS to include our path
/run/current-system/sw/share, so using GLib.get_system_data_dirs
and building paths from those entries should allow compatibility.
Please also note, for compatibility reasons it's almost always
a good idea to go this route.

Fixes #166

---

###### How to test
1. Run with `G_MESSAGES_DEBUG=all` and see it loads the correct system background directory
2. Are there backgrounds in the plug?

###### Note to reviewers
I'm not sure what's being done for `update_accountsservice ()` so I wasn't sure how to adapt it for `get_bg_directories`.