### PR TITLE
Remove applications-menu dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -17,7 +17,7 @@ Homepage: https://github.com/elementary/switchboard-plug-pantheon-shell
 
 Package: switchboard-plug-pantheon-shell
 Architecture: any
-Depends: gala, slingshot-launcher, ${misc:Depends}, ${shlibs:Depends}
+Depends: gala, ${misc:Depends}, ${shlibs:Depends}
 Recommends: plank
 Enhances: switchboard
 Conflicts: switchboard-plug-wallpaper


### PR DESCRIPTION
There are currently no settings that rely on the applications menu, so it doesn't make sense to have this depends