### PR TITLE
Appearance: avoid an unintentional accent change

### DIFF
--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -279,13 +279,13 @@ public class Appearance : Gtk.Grid {
 
             realize.connect (() => {
                 active = current_accent == color_name;
-            });
 
-            clicked.connect (() => {
-                interface_settings.set_string (
-                    STYLESHEET_KEY,
-                    STYLESHEET_PREFIX + color_name
-                );
+                toggled.connect (() => {
+                    interface_settings.set_string (
+                        STYLESHEET_KEY,
+                        STYLESHEET_PREFIX + color_name
+                    );
+                });
             });
         }
     }


### PR DESCRIPTION
I've been having some issues where I open the plug and then all the sudden I get switched to another accent. This seems to fix that