### PR TITLE
Use a selection of image MIME types instead of general image type

### DIFF
--- a/set-wallpaper-contract/set-wallpaper.contract.in
+++ b/set-wallpaper-contract/set-wallpaper.contract.in
@@ -2,6 +2,6 @@
 Name=Set as _Desktop Background
 Icon=preferences-desktop-wallpaper
 Description=Set selected image to be the new desktop background
-MimeType=image
+MimeType=image/bmp;image/gif;image/jpeg;image/png;image/svg+xml;image/tiff
 Exec=@SWEXECDIR@/@EXEC_NAME@ %F
 X-GNOME-Gettext-Domain=@GETTEXT_DOMAIN@


### PR DESCRIPTION
I checked all the common image types for compatibility. BMP, GIF, JPEG, PNG, TIFF work without any problems. SVG works, but looks rather ugly (I imagine the render is scaled form the view box, not the view box itself). This solves the problem in #131, DjVU files no longer can be set as background, only image files with types mentioned above.