### PR TITLE
Option to enable dyslexia-friendly text

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ You'll need the following dependencies:
 
 Run `meson` to configure the build environment and then `ninja` to build
 
-    
     meson build --prefix=/usr
     cd build
     ninja

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You'll need the following dependencies:
 
 Run `meson` to configure the build environment and then `ninja` to build
 
+    
     meson build --prefix=/usr
     cd build
     ninja

--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -24,7 +24,6 @@ public class PantheonShell.Appearance : Gtk.Grid {
     private const string STYLESHEET_PREFIX = "io.elementary.stylesheet.";
     private const string TEXT_SIZE_KEY = "text-scaling-factor";
 
-
     private const string PANEL_SCHEMA = "io.elementary.desktop.wingpanel";
     private const string TRANSLUCENCY_KEY = "use-transparency";
 
@@ -130,6 +129,14 @@ public class PantheonShell.Appearance : Gtk.Grid {
         var dyslexia_font_switch = new Gtk.Switch ();
         dyslexia_font_switch.halign = Gtk.Align.START;
 
+        var dyslexia_font_description_label = new Gtk.Label (
+            _("Bottom-heavy shapes and increased character spacing can help improve legibility and reading speed.")
+        );
+        dyslexia_font_description_label.max_width_chars = 60;
+        dyslexia_font_description_label.wrap = true;
+        dyslexia_font_description_label.xalign = 0;
+        dyslexia_font_description_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+
         /* Row 0 and 1 are for the dark style UI that gets attached only if we
          * can connect to the DBus API
          *
@@ -140,11 +147,11 @@ public class PantheonShell.Appearance : Gtk.Grid {
         attach (animations_switch, 1, 4);
         attach (translucency_label, 0, 5);
         attach (translucency_switch, 1, 5);
-        attach (dyslexia_font_label, 0, 6);
-        attach (dyslexia_font_switch, 1, 6);
-        attach (text_size_label, 0, 7);
-        attach (text_size_modebutton, 1, 7, 2);
-
+        attach (text_size_label, 0, 6);
+        attach (text_size_modebutton, 1, 6, 2);
+        attach (dyslexia_font_label, 0, 7);
+        attach (dyslexia_font_switch, 1, 7);
+        attach (dyslexia_font_description_label, 1, 8);
 
         var animations_settings = new GLib.Settings (ANIMATIONS_SCHEMA);
         animations_settings.bind (ANIMATIONS_KEY, animations_switch, "active", SettingsBindFlags.DEFAULT);

--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -330,22 +330,16 @@ public class PantheonShell.Appearance : Gtk.Grid {
     }
 
     private void toggle_dyslexia_support (GLib.Settings interface_settings, bool state) {
-
-
         if (state == true) {
             interface_settings.set_string (FONT_KEY, OD_REG_FONT);
             interface_settings.set_string (DOCUMENT_FONT_KEY, OD_DOC_FONT);
             interface_settings.set_string (MONOSPACE_FONT_KEY, OD_MON_FONT);
         }
-
         else {
-
             interface_settings.reset (FONT_KEY);
             interface_settings.reset (DOCUMENT_FONT_KEY);
             interface_settings.reset (MONOSPACE_FONT_KEY);
-
         }
-
     }
 
     private bool update_dyslexia_font_switch (GLib.Settings interface_settings) {
@@ -360,7 +354,6 @@ public class PantheonShell.Appearance : Gtk.Grid {
         else {
             return false;
         }
-
     }
 
     private int get_text_scale (GLib.Settings interface_settings) {

--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -151,14 +151,13 @@ public class PantheonShell.Appearance : Gtk.Grid {
         attach (text_size_modebutton, 1, 6, 2);
         attach (dyslexia_font_label, 0, 7);
         attach (dyslexia_font_switch, 1, 7);
-        attach (dyslexia_font_description_label, 1, 8);
+        attach (dyslexia_font_description_label, 1, 8, 2);
 
         var animations_settings = new GLib.Settings (ANIMATIONS_SCHEMA);
         animations_settings.bind (ANIMATIONS_KEY, animations_switch, "active", SettingsBindFlags.DEFAULT);
 
         var panel_settings = new GLib.Settings (PANEL_SCHEMA);
         panel_settings.bind (TRANSLUCENCY_KEY, translucency_switch, "active", SettingsBindFlags.DEFAULT);
-
 
         Pantheon.AccountsService? pantheon_act = null;
 
@@ -349,8 +348,8 @@ public class PantheonShell.Appearance : Gtk.Grid {
 
         if (interface_font == OD_REG_FONT || document_font == OD_DOC_FONT || monospace_font == OD_MON_FONT ) {
             return true;
-
         }
+
         else {
             return false;
         }


### PR DESCRIPTION
This PR adds a toggle to enable dyslexic-friendly system wide fonts to the Appearance switchboard, as discussed in https://github.com/elementary/switchboard-plug-pantheon-shell/issues/234).

Default behaviour:

![default](https://user-images.githubusercontent.com/4386515/88176233-dd2cb000-cc1e-11ea-89da-cb2461cd4c68.png)

And once enabled:

![enabled](https://user-images.githubusercontent.com/4386515/88176247-e289fa80-cc1e-11ea-8048-2e9d59540672.png)
