### PR TITLE
Plug: Add dark style and accent to search results

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -114,6 +114,8 @@ public class PantheonShell.Plug : Switchboard.Plug {
         search_results.set ("%s → %s → %s".printf (display_name, _("Dock"), _("Pressure reveal")), "dock");
         search_results.set ("%s → %s → %s".printf (display_name, _("Dock"), _("Display")), "dock");
         search_results.set ("%s → %s".printf (display_name, _("Appearance")), "appearance");
+        search_results.set ("%s → %s → %s".printf (display_name, _("Appearance"), _("Dark style")), "appearance");
+        search_results.set ("%s → %s → %s".printf (display_name, _("Appearance"), _("Accent color")), "appearance");
         search_results.set ("%s → %s → %s".printf (display_name, _("Appearance"), _("Window animations")), "appearance");
         search_results.set ("%s → %s → %s".printf (display_name, _("Appearance"), _("Panel translucency")), "appearance");
         search_results.set ("%s → %s → %s".printf (display_name, _("Appearance"), _("Text size")), "appearance");


### PR DESCRIPTION
I realized we missed these. This will make them more discoverable in search from the Applications Menu and the Switchboard search.