### PR TITLE
Appearance: Fix alignment of accent help label

### DIFF
--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -387,8 +387,10 @@ public class PantheonShell.Appearance : Gtk.Grid {
             accent_grid.add (cocoa_button);
             accent_grid.add (slate_button);
 
-            var accent_info = new Gtk.Label (_("Used across the system by default. Apps can always use their own accent color."));
-            accent_info.margin_bottom = 18;
+            var accent_info = new Gtk.Label (_("Used across the system by default. Apps can always use their own accent color.")) {
+                margin_bottom = 18,
+                xalign = 0
+            };
             accent_info.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
 
             attach (accent_label, 0, 4);


### PR DESCRIPTION
It was centered on the line, now it's left-aligned like everything else. Changed the margin to use modern code style while here.

### Before

![Screenshot from 2021-04-07 11-17-56](https://user-images.githubusercontent.com/611168/113907928-2e6fd600-9793-11eb-8626-887b1c39aab7.png)


### After

![Screenshot from 2021-04-07 11-17-49](https://user-images.githubusercontent.com/611168/113907946-3465b700-9793-11eb-9e74-116cc320ccac.png)
