### PR TITLE
Add padding to appearance, dock, multitasking views

### DIFF
--- a/src/Views/Appearance.vala
+++ b/src/Views/Appearance.vala
@@ -41,7 +41,7 @@ public class PantheonShell.Appearance : Gtk.Grid {
         column_spacing = 12;
         halign = Gtk.Align.CENTER;
         row_spacing = 6;
-        margin_start = margin_end = 6;
+        margin_start = margin_end = 12;
         margin_bottom = 24;
 
         var dark_label = new Gtk.Label (_("Style:")) {

--- a/src/Views/Dock.vala
+++ b/src/Views/Dock.vala
@@ -162,6 +162,7 @@ public class PantheonShell.Dock : Gtk.Grid {
             halign = Gtk.Align.START
         };
 
+        margin_start = margin_end = 12;
         column_spacing = 12;
         halign = Gtk.Align.CENTER;
         row_spacing = 12;

--- a/src/Views/Dock.vala
+++ b/src/Views/Dock.vala
@@ -163,6 +163,7 @@ public class PantheonShell.Dock : Gtk.Grid {
         };
 
         margin_start = margin_end = 12;
+        margin_bottom = 24;
         column_spacing = 12;
         halign = Gtk.Align.CENTER;
         row_spacing = 12;

--- a/src/Views/Multitasking.vala
+++ b/src/Views/Multitasking.vala
@@ -30,6 +30,7 @@ public class PantheonShell.Multitasking : Gtk.Grid {
 
     construct {
         margin_start = margin_end = 12;
+        margin_bottom = 24;
         column_spacing = 12;
         row_spacing = 6;
         halign = Gtk.Align.CENTER;

--- a/src/Views/Multitasking.vala
+++ b/src/Views/Multitasking.vala
@@ -29,6 +29,7 @@ public class PantheonShell.Multitasking : Gtk.Grid {
     private const string ANIMATIONS_KEY = "enable-animations";
 
     construct {
+        margin_start = margin_end = 12;
         column_spacing = 12;
         row_spacing = 6;
         halign = Gtk.Align.CENTER;


### PR DESCRIPTION
Fixes #267 

I'm not sure what margin I should use from the edge of the window. The HIG seems to say minimum 12 px, which is what I used. (This increased the dock panel padding from 6 px.) But elsewhere in switchboard, there's both 12 px and 24 px. I'm not sure which to use, or if there's a convention I'm missing here. So let me know if I should change the value, it should be pretty easy 🙂️

Also, a question this brought about. Should we have a more standard padding in switchboard? I'd be happy to make a bunch of PRs to standardize other pages to the same value if we want. Let me know.