### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Config.vala.in
+++ b/src/Config.vala.in
@@ -1,3 +1,5 @@
 namespace Constants {
     public const string PLANKDATADIR = "@PLANKDATADIR@";
+    public const string GETTEXT_PACKAGE = "@GETTEXT_PACKAGE@";
+    public const string LOCALEDIR = "@LOCALEDIR@";
 }

--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -25,6 +25,9 @@ public class PantheonShell.Plug : Switchboard.Plug {
     private Wallpaper wallpaper_view;
 
     public Plug () {
+        GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+        GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+
         var settings = new Gee.TreeMap<string, string?> (null, null);
         settings.set ("desktop", null);
         settings.set ("desktop/appearance/wallpaper", "wallpaper");

--- a/src/meson.build
+++ b/src/meson.build
@@ -18,6 +18,8 @@ plank_datadir = plank_dep.get_pkgconfig_variable('pkgdatadir')
 
 configuration = configuration_data()
 configuration.set('PLANKDATADIR', plank_datadir)
+configuration.set('LOCALEDIR', join_paths(get_option('prefix'), get_option('localedir')))
+configuration.set('GETTEXT_PACKAGE', meson.project_name() + '-plug')
 
 config_file = configure_file(
     input: 'Config.vala.in',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)