### PR TITLE
Fix accent color for focused wallpaper

### DIFF
--- a/data/plug.css
+++ b/data/plug.css
@@ -71,7 +71,7 @@
 
 .wallpaper-container:focus .card {
     box-shadow:
-        0 0 0 4px @colorAccent,
+        0 0 0 4px @accent_color,
         0 0 0 1px alpha (#000, 0.05),
         0 3px 3px alpha (#000, 0.22);
 }


### PR DESCRIPTION
I guess colorAccent is from old stylesheet

![image](https://user-images.githubusercontent.com/80143868/183566469-5ee57922-6f01-4ab5-ac62-03719e7695d6.png)
