### PR TITLE
Bump Gala depends to 7.0.2

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://github.com/elementary/switchboard-plug-pantheon-shell
 
 Package: switchboard-plug-pantheon-shell
 Architecture: any
-Depends: gala, ${misc:Depends}, ${shlibs:Depends}
+Depends: gala (>= 7.0.2), ${misc:Depends}, ${shlibs:Depends}
 Recommends: plank
 Enhances: switchboard
 Conflicts: switchboard-plug-wallpaper


### PR DESCRIPTION
Since we're now using a couple of settings keys that were introduced in the latest gala, make sure to bump the runtime dep