### PR TITLE
set-wallpaper: Fix delay value not shown as translated

### DIFF
--- a/set-wallpaper-contract/Config.vala.in
+++ b/set-wallpaper-contract/Config.vala.in
@@ -1,0 +1,3 @@
+namespace Constants {
+    public const string GETTEXT_DOMAIN = "@GETTEXT_DOMAIN@";
+}

--- a/set-wallpaper-contract/meson.build
+++ b/set-wallpaper-contract/meson.build
@@ -13,7 +13,7 @@ wallpaper_contract = configure_file(
     install_dir: join_paths(datadir, 'contractor')
 )
 
-config_file = configure_file(
+contract_config_file = configure_file(
     input: 'Config.vala.in',
     output: '@BASENAME@',
     configuration: contract_configuration
@@ -21,7 +21,7 @@ config_file = configure_file(
 
 executable(
     contract_exec_name,
-    config_file,
+    contract_config_file,
     'set-wallpaper.vala',
     dependencies: [
         glib_dep,

--- a/set-wallpaper-contract/meson.build
+++ b/set-wallpaper-contract/meson.build
@@ -13,8 +13,15 @@ wallpaper_contract = configure_file(
     install_dir: join_paths(datadir, 'contractor')
 )
 
+config_file = configure_file(
+    input: 'Config.vala.in',
+    output: '@BASENAME@',
+    configuration: contract_configuration
+)
+
 executable(
     contract_exec_name,
+    config_file,
     'set-wallpaper.vala',
     dependencies: [
         glib_dep,

--- a/set-wallpaper-contract/set-wallpaper.vala
+++ b/set-wallpaper-contract/set-wallpaper.vala
@@ -91,14 +91,14 @@ namespace SetWallpaperContractor {
         // convert to text and remove fractions from values > 1 minute
         string text;
         if (delay_value < 60) {
-            text = ngettext ("%d second", "%d seconds", delay_value).printf (delay_value);
+            text = dngettext (Constants.GETTEXT_DOMAIN, "%d second", "%d seconds", delay_value).printf (delay_value);
         } else if (delay_value < 60 * 60) {
             int minutes = delay_value / 60;
-            text = ngettext ("%d minute", "%d minutes", minutes).printf (minutes);
+            text = dngettext (Constants.GETTEXT_DOMAIN, "%d minute", "%d minutes", minutes).printf (minutes);
             delay_value = minutes * 60;
         } else if (delay_value < 60 * 60 * 24) {
             int hours = delay_value / (60 * 60);
-            text = ngettext ("%d hour", "%d hours", hours).printf (hours);
+            text = dngettext (Constants.GETTEXT_DOMAIN, "%d hour", "%d hours", hours).printf (hours);
             delay_value = hours * (60 * 60);
         } else {
             text = _("1 day");


### PR DESCRIPTION
## Before
![スクリーンショット 2023-05-04 12 00 11](https://user-images.githubusercontent.com/26003928/236104382-f74e04ba-3140-403e-acfc-543fe67866f7.png)

The delay value is not shown as translated (in this case `1 hour`).

## After
![スクリーンショット 2023-05-04 12 00 00](https://user-images.githubusercontent.com/26003928/236104379-398b4204-baf9-47d4-a5e0-02764d54c5bf.png)

The delay value is shown as translated (in this case `1 hour` is translated to `1時間` in Japanese)
