### PR TITLE
Wallpaper: Confirm wallpaper removal when hidden

### DIFF
--- a/src/Plug.vala
+++ b/src/Plug.vala
@@ -94,6 +94,7 @@ public class PantheonShell.Plug : Switchboard.Plug {
 
     public override void hidden () {
         wallpaper_view.cancel_thumbnail_generation ();
+        wallpaper_view.confirm_removal ();
     }
 
     public override void search_callback (string location) {

--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -655,7 +655,7 @@ public class PantheonShell.Wallpaper : Gtk.Grid {
         });
 
         toast.notify["child-revealed"].connect (() => {
-            if (!toast.child_revealed && wallpaper_for_removal != null) {
+            if (!toast.child_revealed) {
                 confirm_removal ();
             }
         });
@@ -670,6 +670,10 @@ public class PantheonShell.Wallpaper : Gtk.Grid {
     }
 
     public void confirm_removal () {
+        if (wallpaper_for_removal == null) {
+            return;
+        }
+
         var wallpaper_file = File.new_for_uri (wallpaper_for_removal.uri);
         wallpaper_file.trash_async.begin ();
         wallpaper_for_removal.destroy ();

--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -669,7 +669,7 @@ public class PantheonShell.Wallpaper : Gtk.Grid {
         wallpaper_for_removal = wallpaper;
     }
 
-    private void confirm_removal () {
+    public void confirm_removal () {
         var wallpaper_file = File.new_for_uri (wallpaper_for_removal.uri);
         wallpaper_file.trash_async.begin ();
         wallpaper_for_removal.destroy ();


### PR DESCRIPTION
When you remove a wallpaper and immediately close the switchboard, the wallpaper won't be removed. This PR fixes this.