### PR TITLE
set-wallpaper-contract: Port to GTK 4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Dependencies
         run: |
           apt update
-          apt install -y libgnome-desktop-3-dev libgranite-dev libgtk-3-dev libplank-dev libswitchboard-2.0-dev libgexiv2-dev meson valac
+          apt install -y libgnome-desktop-3-dev libgranite-dev libgranite-7-dev libgtk-3-dev libgtk-4-dev libplank-dev libswitchboard-2.0-dev libgexiv2-dev meson valac
       - name: Build
         env:
           DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ You'll need the following dependencies:
 * libgee-0.8-dev
 * libgexiv2-dev
 * libgtk-3-dev (>= 3.22)
+* libgtk-4-dev
 * libplank-dev
 * libgranite-dev
+* libgranite-7-dev
 * meson
 * valac
 

--- a/set-wallpaper-contract/meson.build
+++ b/set-wallpaper-contract/meson.build
@@ -27,8 +27,11 @@ executable(
         glib_dep,
         gio_dep,
         gobject_dep,
-        granite_dep,
-        gtk_dep,
+#        granite_dep,
+#        gtk_dep,
+        # TODO: Re-use the variables above when the plug itself is ported to GTK 4
+        dependency('gtk4'),
+        dependency('granite-7'),
         posix_dep,
         meson.get_compiler('c').find_library('m')
     ],

--- a/set-wallpaper-contract/set-wallpaper.vala
+++ b/set-wallpaper-contract/set-wallpaper.vala
@@ -1,5 +1,5 @@
 /*
-* Copyright 2017-2022 elementary, Inc. (https://elementary.io)
+* Copyright 2017-2023 elementary, Inc. (https://elementary.io)
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -17,7 +17,7 @@
 * Boston, MA 02110-1301 USA
 */
 
-namespace SetWallpaperContractor {
+public class SetWallpaperContractor : Gtk.Application {
     const int DEFAULT_TRANSITION_DURATION = 1;
     const string SLIDESHOW_FILENAME = "slideshow.xml";
 
@@ -39,6 +39,13 @@ namespace SetWallpaperContractor {
     """;
 
     private int delay_value = 60;
+
+    public SetWallpaperContractor () {
+        Object (
+            application_id: "io.elementary.contract.set-wallpaper",
+            flags: GLib.ApplicationFlags.HANDLES_OPEN
+        );
+    }
 
     private void update_slideshow (string path, List<File> files, int duration) {
         var wallpapers = "";
@@ -135,37 +142,25 @@ namespace SetWallpaperContractor {
         return dest;
     }
 
-    public static int main (string[] args) {
-        Gtk.init (ref args);
-
+    public override void open (File[] gfiles, string hint) {
         var folder = ensure_local_bg_exists ();
         var files = new List<File> ();
-        for (var i = 1; i < args.length; i++) {
-            var file = File.new_for_path (args[i]);
-
-            if (file != null) {
-
-                string path = file.get_path ();
-                File append_file = file;
-                if (!path.has_prefix (get_local_bg_directory ())) {
-                    var local_file = copy_for_library (file);
-                    if (local_file != null) {
-                        append_file = local_file;
-                    }
+        foreach (var gfile in gfiles) {
+            string path = gfile.get_path ();
+            File append_file = gfile;
+            if (!path.has_prefix (get_local_bg_directory ())) {
+                var local_file = copy_for_library (gfile);
+                if (local_file != null) {
+                    append_file = local_file;
                 }
-
-                files.append (append_file);
             }
-        }
 
-        if (files.length () < 1) {
-            warning ("No images specified, aborting.\n");
-            return 1;
+            files.append (append_file);
         }
 
         if (files.length () == 1) {
             set_settings_key (files.data.get_uri ());
-            return 0;
+            return;
         }
 
         var duration = new Gtk.Scale.with_range (Gtk.Orientation.HORIZONTAL, 0, 100, 10) {
@@ -180,24 +175,33 @@ namespace SetWallpaperContractor {
             "preferences-desktop-wallpaper",
             Gtk.ButtonsType.CANCEL
         ) {
-            badge_icon = new ThemedIcon ("media-playback-start")
+            badge_icon = new ThemedIcon ("media-playback-start"),
+            application = this
         };
         dialog.add_button (_("Create Slideshow"), Gtk.ResponseType.OK);
         dialog.set_default_response (Gtk.ResponseType.OK);
-        dialog.custom_bin.add (duration);
-        dialog.show_all ();
+        dialog.custom_bin.append (duration);
+        dialog.present ();
 
         delay_value_changed (duration, dialog.secondary_label);
         duration.value_changed.connect (() => delay_value_changed (duration, dialog.secondary_label));
 
-        if (dialog.run () == Gtk.ResponseType.OK) {
-            dialog.destroy ();
+        dialog.response.connect ((response_id) => {
+            if (response_id == Gtk.ResponseType.OK) {
+                var path = folder.get_child (SLIDESHOW_FILENAME).get_path ();
+                update_slideshow (path, files, delay_value);
+            }
 
-            var path = folder.get_child (SLIDESHOW_FILENAME).get_path ();
-            update_slideshow (path, files, delay_value);
-            return 0;
+            dialog.destroy ();
+        });
+    }
+
+    public static int main (string[] args) {
+        if (args.length == 1) {
+            warning ("No images specified, aborting.");
+            return 1;
         }
 
-        return 1;
+        return new SetWallpaperContractor ().run (args);
     }
 }


### PR DESCRIPTION
set-wallpaper-contract can be ported to GTK 4 because its source is separated from the plug itself which is not ported to GTK 4 yet