### PR TITLE
fix(wallpaper): change wallpaper for dark theme settings

### DIFF
--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -206,6 +206,7 @@ public class PantheonShell.Wallpaper : Gtk.Box {
         }
 
         gnome_background_settings.set_string ("picture-uri", uri);
+        gnome_background_settings.set_string ("picture-uri-dark", uri);
     }
 
     private void update_checked_wallpaper (Gtk.FlowBox box, Gtk.FlowBoxChild child) {

--- a/src/Views/Wallpaper.vala
+++ b/src/Views/Wallpaper.vala
@@ -206,7 +206,7 @@ public class PantheonShell.Wallpaper : Gtk.Box {
         }
 
         gnome_background_settings.set_string ("picture-uri", uri);
-        gnome_background_settings.set_string ("picture-uri-dark", uri);
+        gnome_background_settings.set_string ("picture-uri-dark", "");
     }
 
     private void update_checked_wallpaper (Gtk.FlowBox box, Gtk.FlowBoxChild child) {


### PR DESCRIPTION
Previously before the fix, the wallpaper cannot be changed via settings because it only sets the wallpaper for the light theme, not the dark theme. This fixes the issue.