### PR TITLE
Control: bump settings-daemon runtime dep

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -18,7 +18,7 @@ Homepage: https://github.com/elementary/switchboard-plug-pantheon-shell
 Package: io.elementary.settings.desktop
 Architecture: any
 Depends: gala (>= 8.0.0),
-         io.elementary.settings-daemon (>=8.3.1),
+         io.elementary.settings-daemon (>=8.4.0),
          ${misc:Depends},
          ${shlibs:Depends}
 Recommends: io.elementary.dock


### PR DESCRIPTION
8.4.0 is when Latte is included in settings daemon